### PR TITLE
Switch to log-return prediction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 data/processed/
 data/raw/
 results/
+venv/

--- a/scripts/03_entrenamiento_modelo.py
+++ b/scripts/03_entrenamiento_modelo.py
@@ -66,11 +66,10 @@ predictions = model.predict(X_val)
 y_val_denorm = np.array([denormalize_value(y, p) for y, p in zip(y_val, y_params_val)])
 predictions_denorm = np.array([denormalize_value(y, p) for y, p in zip(predictions, y_params_val)])
 
-mae, rmse, mape = calculate_all_metrics(y_val_denorm, predictions_denorm)
+mae, rmse = calculate_all_metrics(y_val_denorm, predictions_denorm)
 
 print(f"MAE: {mae}")
 print(f"RMSE: {rmse}")
-print(f"MAPE (%): {mape}")
 
 # Visualización de predicciones vs realidad (con datos desnormalizados)
 plot_actual_vs_predicted(pd.Series(y_val_denorm), pd.Series(predictions_denorm), title="Predicción vs Realidad (con datos desnormalizados)")

--- a/scripts/04_evaluacion_predicciones.py
+++ b/scripts/04_evaluacion_predicciones.py
@@ -64,10 +64,9 @@ def main() -> None:
     predictions_denorm = np.array([denormalize_value(y, p) for y, p in zip(predictions, y_params_test)])
 
     # Calcular métricas
-    mae, rmse, mape = calculate_all_metrics(y_test_denorm, predictions_denorm)
+    mae, rmse = calculate_all_metrics(y_test_denorm, predictions_denorm)
     print(f"MAE: {mae}")
     print(f"RMSE: {rmse}")
-    print(f"MAPE (%): {mape}")
 
     # Visualizaciones
     actual_series = pd.Series(y_test_denorm, index=test_dates)

--- a/src/pipeline/evaluate.py
+++ b/src/pipeline/evaluate.py
@@ -40,8 +40,7 @@ def evaluate_model(model_name: str, series_ticker: str) -> dict[str, float]:
     # Evalúa las predicciones
     metrics = {
         "MAE": calculate_mean_absolute_error(y_test, predictions),
-        "RMSE": calculate_root_mean_squared_error(y_test, predictions),
-        "MAPE": calculate_mean_absolute_percentage_error(y_test, predictions)
+        "RMSE": calculate_root_mean_squared_error(y_test, predictions)
     }
 
     return metrics

--- a/src/utils/metrics.py
+++ b/src/utils/metrics.py
@@ -26,9 +26,8 @@ def calculate_mean_absolute_percentage_error(true_values: np.ndarray, predicted_
 
 
 # Nueva función para calcular todas las métricas a la vez
-def calculate_all_metrics(true_values: np.ndarray, predicted_values: np.ndarray) -> tuple[float, float, float]:
-    """Calcula MAE, RMSE y MAPE en una sola llamada."""
+def calculate_all_metrics(true_values: np.ndarray, predicted_values: np.ndarray) -> tuple[float, float]:
+    """Calcula MAE y RMSE en una sola llamada."""
     mae = calculate_mean_absolute_error(true_values, predicted_values)
     rmse = calculate_root_mean_squared_error(true_values, predicted_values)
-    mape = calculate_mean_absolute_percentage_error(true_values, predicted_values)
-    return mae, rmse, mape
+    return mae, rmse

--- a/src/utils/preprocessing.py
+++ b/src/utils/preprocessing.py
@@ -46,16 +46,17 @@ def create_sliding_windows(df: pd.DataFrame, window_size: int) -> tuple[np.ndarr
         window_norm = normalize_values(window, method=NORMALIZATION_METHOD)
         X.append(window_norm.values)
 
-        target_seq = window[target_column].values
-        y_value = df[target_column].iloc[end]
+        prices = window[target_column].values
+        log_returns = np.log(prices[1:] / prices[:-1])
+        y_value = np.log(df[target_column].iloc[end] / df[target_column].iloc[end - 1])
 
         if NORMALIZATION_METHOD == "standard":
-            mean, std = target_seq.mean(), target_seq.std()
+            mean, std = log_returns.mean(), log_returns.std()
             y_params.append((mean, std))
             y.append((y_value - mean) / std if std else 0.0)
 
         else:
-            min_val, max_val = target_seq.min(), target_seq.max()
+            min_val, max_val = log_returns.min(), log_returns.max()
             rng = max_val - min_val
             y_params.append((min_val, max_val))
             y.append((y_value - min_val) / rng if rng else 0.0)


### PR DESCRIPTION
## Summary
- ignore venv directory
- generate log-return targets in sliding windows
- track MAE and RMSE only
- update training and evaluation scripts accordingly

## Testing
- `python -m pip install -r requirements.txt` *(fails: blocked by environment)*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6874cbb0c4a48329ba41e260c8eeb8bc