### PR TITLE
Improve preprocessing and config options

### DIFF
--- a/scripts/02_procesamiento_datos.py
+++ b/scripts/02_procesamiento_datos.py
@@ -6,7 +6,18 @@ import sys
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 sys.path.append(str(PROJECT_ROOT))
 
-from src.config import DATA_PATH, PROCESSED_DATA_PATH, WINDOW_SIZE, TRAIN_START, VALIDATION_START, TEST_START, TEST_END
+from src.config import (
+    DATA_PATH,
+    PROCESSED_DATA_PATH,
+    WINDOW_SIZE,
+    TRAIN_START,
+    TRAIN_END,
+    VALIDATION_START,
+    TEST_START,
+    TEST_END,
+    SELECTED_FEATURES,
+    NORMALIZATION_METHOD,
+)
 from src.utils.preprocessing import create_sliding_windows
 
 
@@ -19,14 +30,19 @@ for column in volume_columns:
     combined_data[column] = np.log1p(combined_data[column])
 
 # Crear ventanas deslizantes
-X, y, y_params = create_sliding_windows(combined_data, window_size=WINDOW_SIZE)
+X, y, y_params = create_sliding_windows(
+    combined_data,
+    window_size=WINDOW_SIZE,
+    normalization_method=NORMALIZATION_METHOD,
+    exclude_columns=SELECTED_FEATURES,
+)
 
 # Extraer índice temporal para filtrado
 dates = combined_data.index[WINDOW_SIZE:]  # una fecha por cada valor y
 
 # Dividir por conjuntos usando fechas
-train_mask = (dates >= TRAIN_START) & (dates < VALIDATION_START)
-val_mask = (dates >= VALIDATION_START) & (dates < TEST_START)
+train_mask = (dates >= TRAIN_START) & (dates <= TRAIN_END)
+val_mask = (dates > TRAIN_END) & (dates < TEST_START)
 test_mask = (dates >= TEST_START) & (dates <= TEST_END)
 
 X_train, y_train, y_train_params = X[train_mask], y[train_mask], [y_params[i] for i in range(len(train_mask)) if train_mask[i]]

--- a/scripts/03_entrenamiento_modelo.py
+++ b/scripts/03_entrenamiento_modelo.py
@@ -63,9 +63,10 @@ elif model_type == "prophet":
     prophet_df = df[[TARGET_COLUMN]].iloc[WINDOW_SIZE:][train_dates].copy()
     prophet_df = prophet_df.reset_index().rename(columns={"index": "ds", TARGET_COLUMN: "y"})
     model_path = train_model("prophet", prophet_df)
+    validation_series = df.loc[validation_dates, TARGET_COLUMN]
     model = load(model_path)
-    preds = model.predict(X_val)
-    real = y_val
+    preds = model.predict(len(validation_series))
+    real = validation_series
 else:
     model_path = train_model(model_type, X_train, y_train, X_val, y_val)
     model = load(model_path)

--- a/src/config.py
+++ b/src/config.py
@@ -14,8 +14,16 @@ TEST_END = "2024-12-31"
 
 # ===================== Configuración del experimento =====================
 WINDOW_SIZE = 20
-MODEL_TYPE = "arima" 
+MODEL_TYPE = "arima"
 SEED = 42
+
+# Características seleccionadas para el entrenamiento. Si se deja en ``None``
+# se utilizan todas las columnas disponibles en los datos procesados.
+SELECTED_FEATURES: list[str] | None = None
+
+# Método de normalización global para ``create_sliding_windows``. Actualmente
+# solo se admite "standard" o "minmax".
+NORMALIZATION_METHOD = "standard"
 
 # ===================== Configuración de entrenamiento =====================
 EARLY_STOPPING_PATIENCE = 10

--- a/src/pipeline/train.py
+++ b/src/pipeline/train.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from joblib import dump
 import pandas as pd
 
-from ..config import MODEL_PATH, TARGET_COLUMN, WINDOW_SIZE
+from ..config import MODEL_PATH, TARGET_COLUMN, WINDOW_SIZE, NORMALIZATION_METHOD
 from ..models.lstm_model import LSTMModel
 from ..models.gru_model import GRUModel
 from ..models.transformer_model import TransformerModel
@@ -38,7 +38,7 @@ def train_model(model_name: str, X_train, y_train=None, X_val=None, y_val=None) 
         model_instance.fit(X_train, y_train, validation_data=(X_val, y_val))
 
     MODEL_PATH.mkdir(parents=True, exist_ok=True)
-    model_output_path = MODEL_PATH / f"{model_name}_{TARGET_COLUMN}_w{WINDOW_SIZE}.pkl"
+    model_output_path = MODEL_PATH / f"{model_name}_{TARGET_COLUMN}_w{WINDOW_SIZE}_{NORMALIZATION_METHOD}.pkl"
     dump(model_instance, model_output_path)
     print(f"Modelo '{model_name}' entrenado y guardado en: {model_output_path}")
     return model_output_path


### PR DESCRIPTION
## Summary
- add feature selection and normalization options to config
- enhance `create_sliding_windows` with column exclusion
- use TRAIN_END when splitting dataset and allow optional feature selection
- refine Prophet validation logic
- include normalization method in saved model filenames

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e4eb2c808329a0d892c02d40ac7e